### PR TITLE
Fix: Whitespace errors

### DIFF
--- a/src/dhali/transaction_utils.py
+++ b/src/dhali/transaction_utils.py
@@ -378,7 +378,7 @@ async def validate_exact_claim(
             status_code=500,
         )
     
-    if estimated_payment_claim_doc.get("payment_claim") != claim:
+    if estimated_payment_claim_doc.get("payment_claim").strip(" ") != claim.strip(" "):
         logging.error(f'Error: {estimated_payment_claim_doc.get("payment_claim")} != {claim}')
         raise HTTPException(
             status_code=500,


### PR DESCRIPTION
## What does this PR do

* When `json.loads` and `json.dumps` are called on a json object, it can introduce whitespace which causes unnecessary validation error. This fixes that.

## How should this PR be tested?

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
