### PR TITLE
Add rate limiting

### DIFF
--- a/src/dhali/rate_limiter.py
+++ b/src/dhali/rate_limiter.py
@@ -1,0 +1,92 @@
+from fastapi import HTTPException
+import datetime
+
+
+class RateLimitStrategy:
+    """
+    Base rate limit strategy class.
+
+    Provides a default implementation for rate limiting checks, which always returns False, 
+    meaning no rate limiting by default.
+    """
+    def should_limit(self, *args, **kwargs):
+        """
+        Determine if a request should be rate limited.
+
+        :return: False by default, meaning no rate limiting.
+        """
+        return False
+
+
+class PaymentClaimBufferStrategy(RateLimitStrategy):
+    """
+    A specific rate limit strategy based on the number of claims staged and their timestamps.
+
+    Rate limits if the number of claims staged exceeds the limit within the last {seconds_to_apply_over} second.
+    """
+    def __init__(self, claim_buffer_size_limit: int, seconds_to_apply_over: float = 1):
+        """
+        Initializes with a specified claim buffer size limit.
+
+        :param claim_buffer_size_limit: The maximum number of claims allowed within the buffer.
+        """
+        self.apply_over_last = seconds_to_apply_over
+        self._claim_buffer_size_limit = claim_buffer_size_limit
+
+    def should_limit(self, *args, **kwargs):
+        """
+        Determine if a request should be rate limited based on claim count and timestamp.
+
+        :return: True if the claims exceed the limit and the timestamp is within the last {self.time_difference}, else False.
+        """
+        if (
+            "number_of_claims_staged" in kwargs
+            and kwargs["number_of_claims_staged"] >= self._claim_buffer_size_limit
+        ):
+            if "timestamp" in kwargs:
+                timestamp = kwargs["timestamp"]
+
+                # Assuming timestamp is a datetime object. If it's a string, parse it first.
+                time_difference = datetime.datetime.utcnow() - timestamp
+
+                if time_difference < datetime.timedelta(seconds=self.apply_over_last):
+                    return True
+        return False
+
+
+class RateLimiter:
+    """
+    A callable rate limiter that utilizes a rate limiting strategy to determine if a request should be limited.
+    """
+    def __init__(self, strategy: RateLimitStrategy = RateLimitStrategy()):
+        """
+        Initializes with a specified rate limiting strategy.
+
+        :param strategy: The rate limiting strategy to be used. Defaults to the base RateLimitStrategy.
+        """
+        self.strategy = strategy
+
+    def __call__(self, *args, **kwargs):
+        """
+        Checks if a request should be rate limited based on the strategy. 
+
+        Raises an exception if the request is to be rate limited.
+        """
+        if self.strategy.should_limit(*args, **kwargs):
+            raise HTTPException(status_code=429, detail="Too Many Requests")
+
+
+if __name__ == "__main__":
+    # Usage
+    payment_claim_buffer_strategy = PaymentClaimBufferStrategy(
+        claim_buffer_size_limit=5
+    )
+    payment_claim_buffer_limiter = RateLimiter(payment_claim_buffer_strategy)
+
+    claim = {"number_of_claims_staged": 6, "timestamp": datetime.datetime.utcnow()}
+    try:
+        payment_claim_buffer_limiter(
+            **claim
+        )  # Checks the payment claim buffer strategy
+    except HTTPException as e:
+        print(f"This exception was expected: {e}")

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi import HTTPException
+from dhali.rate_limiter import PaymentClaimBufferStrategy, RateLimiter
+import datetime
+
+def test_default_strategy_does_not_limit():
+    limiter = RateLimiter()
+    assert limiter() is None  # Default strategy does not limit
+
+def test_claim_buffer_strategy_limits():
+    strategy = PaymentClaimBufferStrategy(claim_buffer_size_limit=5)
+    limiter = RateLimiter(strategy)
+
+    claim_within_limit = {
+        "number_of_claims_staged": 4,
+        "timestamp": datetime.datetime.utcnow()
+    }
+    
+    assert limiter(**claim_within_limit) is None  # Does not limit
+
+    claim_exceeding_limit = {
+        "number_of_claims_staged": 6,
+        "timestamp": datetime.datetime.utcnow()
+    }
+    
+    with pytest.raises(HTTPException) as excinfo:
+        limiter(**claim_exceeding_limit)
+    assert str(excinfo.value.detail) == "Too Many Requests"
+
+def test_claim_buffer_strategy_timestamps():
+    strategy = PaymentClaimBufferStrategy(claim_buffer_size_limit=5)
+    limiter = RateLimiter(strategy)
+    
+    recent_timestamp = datetime.datetime.utcnow() - datetime.timedelta(milliseconds=500)
+    claim_with_recent_timestamp = {
+        "number_of_claims_staged": 6,
+        "timestamp": recent_timestamp
+    }
+    
+    with pytest.raises(HTTPException) as excinfo:
+        limiter(**claim_with_recent_timestamp)
+    assert str(excinfo.value.detail) == "Too Many Requests"
+
+    older_timestamp = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+    claim_with_older_timestamp = {
+        "number_of_claims_staged": 6,
+        "timestamp": older_timestamp
+    }
+    
+    assert limiter(**claim_with_older_timestamp) is None  # Does not limit due to older timestamp
+


### PR DESCRIPTION
## What does this PR do

This PR adds timestamp and number_of_claims_staged entries to the root claim.

When validating the estimated claim, if the most recent insertion to the root doc consolidated more than "rate_limit" docs and this occurred within 1 second, the claim is rejected.

## How should this PR be tested?

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
