### PR TITLE
fix pytest deprecation warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,21 +50,6 @@ package_dir =
 install_requires =
     importlib-metadata; python_version<"3.8"
     xrpl-py==2.5.0
-    fastapi==0.109.0
-    google==3.0.0
-    google-api-core==2.11.0
-    google-auth==2.16.2
-    google-cloud==0.34.0
-    google-cloud-vision==3.4.0
-    googleapis-common-protos==1.58.0
-    google-cloud-firestore==2.10.0
-    mockito==1.4.0
-    mock-firestore==0.11.0
-    pytest-asyncio==0.21.0
-
-
-
-
 
 
 [options.packages.find]


### PR DESCRIPTION
## What does this PR do
* At the moment, I get a lot of `pytest` warnings that look like this:
```
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/google/rpc/__init__.py:18
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/google/rpc/__init__.py:18: DeprecationWarning: pkg_resources is deprecate
d as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources  

../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: 14 warnings
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `p
kg_resources.declare_namespace('google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa
.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)   
./../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868                                       
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868                                       ../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868                                       
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868                 
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `p
kg_resources.declare_namespace('google.cloud')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa
.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2348
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2348
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2348
../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2348
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2348: DeprecationWarning: Deprecated call to `p
kg_resources.declare_namespace('google')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa
.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(parent)

../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `p
kg_resources.declare_namespace('google.logging')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa
.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `p
kg_resources.declare_namespace('google.iam')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa
.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

../../../../../.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/google/rpc/__init__.py:20
  /home/__/.pyenv/versions/3.10.2/envs/dhali/lib/python3.10/site-packages/google/rpc/__init__.py:20: DeprecationWarning: Deprecated call to `pkg_re
sources.declare_namespace('google.rpc')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa
.io/en/latest/references/keywords.html#keyword-namespace-packages
    pkg_resources.declare_namespace(__name__)
```
    
It's caused by using google dependencies that use deprecated packaging features.  So this PR removes those dependencies (currently unused)  removing the `pytest` warnings.

## How should this PR be tested?
- [ ] Confirm you agree with the proposed changes.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
